### PR TITLE
Fixed some issues that lead to compile errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(iso): $(kernel) $(grub_cfg)
 	@mkdir -p target/isofiles/boot/grub
 	@cp $(kernel) target/isofiles/boot/kernel.bin
 	@cp $(grub_cfg) target/isofiles/boot/grub
-	@grub-mkrescue -o $(iso) target/isofiles 2> /dev/null
+	@grub-mkrescue -o $(iso) target/isofiles # 2> /dev/null
 	@rm -r target/isofiles
 
 $(kernel): $(rust_os) $(assembly_object_files) $(linker_script)

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["staticlib"]
 [dependencies]
 spin = "0.5.2"
 uart_16550 = "0.2.10"
-x86_64 = "0.12.0"
+x86_64 = "0.14.7"
 pc-keyboard = "0.3.1"
 multiboot2 = "0.1.0"
 if_chain = "1.0.0"
 
 [dependencies.lazy_static]
-version = "1.0"
+version = "1.4.0"
 features = ["spin_no_std"]
 
 [features]

--- a/kernel/src/gdt.rs
+++ b/kernel/src/gdt.rs
@@ -1,6 +1,6 @@
 use crate::println;
 use lazy_static::lazy_static;
-use x86_64::instructions::segmentation::{load_ds, set_cs};
+use x86_64::instructions::segmentation::{Segment, CS,DS};
 use x86_64::instructions::tables::load_tss;
 use x86_64::structures::gdt::{
     Descriptor, DescriptorFlags, GlobalDescriptorTable, SegmentSelector,
@@ -56,8 +56,10 @@ pub fn init_gdt() {
         &GDT.0 as *const _, &*TSS as *const _, stack, user_stack, GDT.1[0].0, GDT.1[1].0
     );
     unsafe {
-        set_cs(GDT.1[0]);
-        load_ds(GDT.1[1]);
+        CS::set_reg(GDT.1[0]);
+        // set_cs(GDT.1[0]);
+        // load_ds(GDT.1[1]);
+        DS::set_reg(GDT.1[1]);
         load_tss(GDT.1[2]);
     }
 }
@@ -68,6 +70,7 @@ pub unsafe fn set_usermode_segs() -> (u16, u16) {
     let (mut cs, mut ds) = (GDT.1[4], GDT.1[3]);
     cs.0 |= PrivilegeLevel::Ring3 as u16;
     ds.0 |= PrivilegeLevel::Ring3 as u16;
-    load_ds(ds);
+    // load_ds(ds);
+    DS::set_reg(ds);
     (cs.0, ds.0)
 }

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -5,6 +5,9 @@ use lazy_static::lazy_static;
 use spin::Mutex;
 
 use x86_64::instructions::segmentation;
+// use x86_64::registers::Segment;
+use x86_64::registers::segmentation::Segment;
+use x86_64::registers::segmentation::CS;
 use x86_64::instructions::tables::{lidt, DescriptorTablePointer};
 use x86_64::structures::gdt::SegmentSelector;
 use x86_64::structures::idt::InterruptStackFrame;
@@ -55,6 +58,7 @@ extern "x86-interrupt" fn double_fault(stack_frame: &mut InterruptStackFrame, er
     loop {}
 }
 
+// this naked is necessary (as is for most/all interrupts)
 #[naked]
 unsafe extern "C" fn timer(_stack_frame: &mut InterruptStackFrame) {
     let ctx = scheduler::get_context();
@@ -83,14 +87,14 @@ lazy_static! {
         macro_rules! idt_entry {
             ($i:literal, $e:expr) => {
                 vectors[$i] =
-                    IDTEntry::new($e as *const IDTHandler, segmentation::cs(), 0, true, 0);
+                    IDTEntry::new($e as *const IDTHandler, CS::get_reg(), 0, true, 0);
             };
         }
         idt_entry!(0, div_by_zero);
         idt_entry!(3, breakpoint);
         vectors[8] = IDTEntry::new(
             double_fault as *const IDTHandler,
-            segmentation::cs(),
+            CS::get_reg(),
             crate::gdt::DOUBLE_FAULT_IST_INDEX + 1,
             true,
             0,
@@ -175,7 +179,7 @@ impl IDTEntry {
             handler_mid: 0,
             handler_hi: 0,
             options: 0,
-            gdt_selector: segmentation::cs().0,
+            gdt_selector: CS::get_reg().0,
             reserved: 0,
         }
     }

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -12,6 +12,7 @@ use x86_64::structures::idt::InterruptStackFrame;
 use pc_keyboard::{layouts, DecodedKey, Keyboard, ScancodeSet1};
 
 use core::mem::size_of;
+use x86_64::VirtAddr;
 
 type IDTHandler = extern "x86-interrupt" fn();
 
@@ -108,7 +109,9 @@ struct InterruptDescriptorTable([IDTEntry; 0x100]);
 impl InterruptDescriptorTable {
     fn load(&'static self) {
         let idt_ptr = DescriptorTablePointer {
-            base: self as *const _ as u64,
+            // base: self as *const _ as u64,
+            //^^^^^^^^^^^^^^^^^^^^^^^ expected struct `x86_64::VirtAddr`, found `u64`
+            base:  VirtAddr::from_ptr(self as *const _),//_ as x86_64::VirtAddr,
             limit: (size_of::<Self>() - 1) as u16,
         };
         println!(" - Setting up IDT with {} entries", INTERRUPT_TABLE.0.len());

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -107,10 +107,13 @@ pub fn start(boot_info: &'static BootInformation) -> ! {
         mem::VirtAddr::new(userspace::userspace_prog_1 as *const () as u64);
     let userspace_fn_2_in_kernel =
         mem::VirtAddr::new(userspace::userspace_prog_2 as *const () as u64);
+    let userspace_fn_hello_in_kernel =
+        mem::VirtAddr::new(userspace::userspace_prog_hello as *const () as u64);
     unsafe {
         let sched = &scheduler::SCHEDULER;
         sched.schedule(userspace_fn_1_in_kernel);
         sched.schedule(userspace_fn_2_in_kernel);
+        sched.schedule(userspace_fn_hello_in_kernel);
         loop {
             sched.run_next();
         }

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -67,9 +67,9 @@ fn handle_syscall() {
         pop rsi
         pop rdi
         pop rax
-        mov rsp, rbx // move our stack to the newly allocated one
+        mov rsp, r9 // move our stack to the newly allocated one
         sti // enable interrupts",
-        inout("rbx") stack_ptr => _);
+        inout("r9") stack_ptr => _);
     }
     let syscall: u64;
     let arg0: u64;

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -37,7 +37,23 @@ fn sys1(a: u64, b: u64, c: u64, d: u64) -> i64 {
     456
 }
 
-#[naked]
+
+#[inline(never)]
+fn sys_hello(a: u64, b: u64, c: u64, d: u64) -> i64 {
+    println!("hello world! {:x} {:x} {:x} {:x}", a, b, c, d);
+    0
+}
+
+#[inline(never)]
+fn sys_unhandled() -> i64 {
+    // println!("bad syscall number!");
+    panic!("bad syscall number!");
+    0xdeadbeef
+}
+
+
+// naked functions are supposed to be a single asm block
+// #[naked]
 fn handle_syscall() {
     unsafe {
         asm!("\
@@ -84,7 +100,8 @@ fn handle_syscall() {
     let retval: i64 = match syscall {
         0x595ca11a => sys0(arg0, arg1, arg2, arg3),
         0x595ca11b => sys1(arg0, arg1, arg2, arg3),
-        _ => -1,
+        0x42 => sys_hello(arg0, arg1, arg2, arg3),
+        _ => sys_unhandled(),
     };
     unsafe {
         asm!("\

--- a/kernel/src/userspace.rs
+++ b/kernel/src/userspace.rs
@@ -1,8 +1,14 @@
 #[naked]
 pub unsafe fn userspace_prog_1() {
+    /*
+    error if named labels used in inline asm:
+    = note: `#[deny(named_asm_labels)]` on by default
+    = help: only local labels of the form `<number>:` should be used in inline asm
+    https://doc.rust-lang.org/unstable-book/library-features/asm.html#labels
+    */
     asm!("\
         mov rbx, 0xf0000000
-        prog1start:
+        2: // prog1 start
         push 0x595ca11a // keep the syscall number in the stack
         mov rbp, 0x0 // distinct values for each register
         mov rax, 0x1
@@ -18,16 +24,16 @@ pub unsafe fn userspace_prog_1() {
         mov r14, 0x13
         mov r15, 0x14
         xor rax, rax
-        prog1loop:
+        3: //prog 1 loop
         inc rax
         cmp rax, 0x4000000
-        jnz prog1loop // loop for some milliseconds
+        jnz 3b // loop for some milliseconds
         pop rax // pop syscall number from the stack
         inc rbx // increase loop counter
         mov rdi, rsp // first syscall arg is rsp
         mov rsi, rbx // second syscall arg is the loop counter
         syscall // perform the syscall!
-        jmp prog1start // do it all over
+        jmp 2b // do it all over
     ");
 }
 
@@ -35,7 +41,7 @@ pub unsafe fn userspace_prog_1() {
 pub unsafe fn userspace_prog_2() {
     asm!("\
         mov rbx, 0
-        prog2start:
+        4: // prog2start
         push 0x595ca11b // keep the syscall number in the stack
         mov rbp, 0x100 // distinct values for each register
         mov rax, 0x101
@@ -51,15 +57,15 @@ pub unsafe fn userspace_prog_2() {
         mov r14, 0x113
         mov r15, 0x114
         xor rax, rax
-        prog2loop:
+        5: //prog2loop
         inc rax
         cmp rax, 0x4000000
-        jnz prog2loop // loop for some milliseconds
+        jnz 5b // loop for some milliseconds
         pop rax // pop syscall number from the stack
         inc rbx // increase loop counter
         mov rdi, rsp // first syscall arg is rsp
         mov rsi, rbx // second syscall arg is the loop counter
         syscall // perform the syscall!
-        jmp prog2start // do it all over
+        jmp 4b // do it all over
     ");
 }

--- a/kernel/src/userspace.rs
+++ b/kernel/src/userspace.rs
@@ -6,6 +6,7 @@ pub unsafe fn userspace_prog_1() {
     = help: only local labels of the form `<number>:` should be used in inline asm
     https://doc.rust-lang.org/unstable-book/library-features/asm.html#labels
     */
+    
     asm!("\
         mov rbx, 0xf0000000
         2: // prog1 start
@@ -34,7 +35,7 @@ pub unsafe fn userspace_prog_1() {
         mov rsi, rbx // second syscall arg is the loop counter
         syscall // perform the syscall!
         jmp 2b // do it all over
-    ");
+    ", options(noreturn));
 }
 
 #[naked]
@@ -67,5 +68,24 @@ pub unsafe fn userspace_prog_2() {
         mov rsi, rbx // second syscall arg is the loop counter
         syscall // perform the syscall!
         jmp 4b // do it all over
-    ");
+    ",options(noreturn));
+}
+
+#[naked]
+pub unsafe fn userspace_prog_hello() {
+    asm!("\
+            42:
+            mov rax, 0x42 // syscall number in rax
+            mov rdi, rsp // first syscall arg is rsp
+            mov rsi, 0 // second syscall arg is some number
+
+            xor rcx,rcx
+            43: // make a loop so it doesn go forever?
+            inc rcx
+            cmp rcx, 0x4000000
+            jnz 43b //loop for some milliseconds
+
+            syscall // perform the syscall!
+            jmp 42b // 1 for the label 1: , b for before (the one closet before)
+        ",options(noreturn));
 }


### PR DESCRIPTION
There were few errors during `make run` due to new nightly changes in rust. Also version bumped some stuff.

Major Errors fixed:
expected struct `x86_64::VirtAddr`, found `u64` in interrupts.src
rbx is used internally by LLVM and cannot be used as an operand for inline asm" in syscalls.rs
named inline asm labels no longer allowed

tested on `rustc 1.59.0-nightly (0b42deacc 2021-12-09)`

